### PR TITLE
TC_002.013.004 |Product page > Color choice block>No text near "Color" by default

### DIFF
--- a/cypress/e2e/productPageColorChoiceBlock.cy.js
+++ b/cypress/e2e/productPageColorChoiceBlock.cy.js
@@ -56,6 +56,15 @@ beforeEach(() => {
      
      
   });
+
+  it("TC_002.013.004 ProductP>Color choice block>No text near 'Color' by default", () => {
+    productPage
+      .getColorText()
+      .next()
+      .should('have.text','');
+        
+  });
+
 });
 
 

--- a/cypress/pageObjects/ProductPage.js
+++ b/cypress/pageObjects/ProductPage.js
@@ -23,7 +23,7 @@ class ProductPage {
     getColorBlock = () => cy.get('div.swatch-attribute.color'); 
     getColorItem = () => cy.get('div.swatch-option.color');
     getContainer = () => cy.get('div.swatch-attribute-options.clearfix');
-    
+    getColorText = () => cy.get('#option-label-color-93');
   compareNameAndEndPoint() {
     this.getProductName().then(($el)=>{
       let text = $el.text().toLowerCase().split(' ').join('-')


### PR DESCRIPTION
https://trello.com/c/1Vifu6ex/52-tc002013004-product-page-color-choice-blockno-text-near-color-by-default